### PR TITLE
Add test for uninitialized bond curve and fix check

### DIFF
--- a/src/abstract/CSBondCurve.sol
+++ b/src/abstract/CSBondCurve.sol
@@ -249,7 +249,7 @@ abstract contract CSBondCurve is ICSBondCurve, Initializable {
         uint256 curveId
     ) private view returns (BondCurve storage) {
         CSBondCurveStorage storage $ = _getCSBondCurveStorage();
-        if (curveId > $.bondCurves.length - 1) {
+        if (curveId >= $.bondCurves.length) {
             revert InvalidBondCurveId();
         }
 

--- a/test/CSBondCurve.t.sol
+++ b/test/CSBondCurve.t.sol
@@ -54,6 +54,11 @@ contract CSBondCurveInitTest is Test {
         vm.expectRevert(ICSBondCurve.InvalidInitializationCurveId.selector);
         bondCurve.initialize(_bondCurve);
     }
+
+    function test_getCurveInfo_uninitialized_reverts() public {
+        vm.expectRevert(ICSBondCurve.InvalidBondCurveId.selector);
+        bondCurve.getCurveInfo(0);
+    }
 }
 
 contract CSBondCurveTest is Test {


### PR DESCRIPTION
## Summary
- cover `getCurveInfo` call on uninitialized CSBondCurve
- avoid underflow in `_getCurveInfo`

## Testing
- `just test-unit --match-path test/CSBondCurve.t.sol`

------
https://chatgpt.com/codex/tasks/task_b_684acbed5ef48321a5cc9b1f635b73f0