### PR TITLE
Fix typo in SigningKeys.sol comment

### DIFF
--- a/src/lib/SigningKeys.sol
+++ b/src/lib/SigningKeys.sol
@@ -162,7 +162,7 @@ library SigningKeys {
     /// @param nodeOperatorId operator id
     /// @param startIndex start index
     /// @param keysCount keys count to load
-    /// @param pubkeys preallocated kes buffer to read in
+    /// @param pubkeys preallocated keys buffer to read in
     /// @param signatures preallocated signatures buffer to read in
     /// @param bufOffset start offset in `pubkeys`/`signatures` buffer to place values (in number of keys)
     function loadKeysSigs(


### PR DESCRIPTION
## Summary
- fix typo in `loadKeysSigs` comment

## Testing
- `just test-unit` *(fails: could not complete due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_b_684acbeef5408321869b76b0bbc273ba