### PR TITLE
Fix bond curve ID checks

### DIFF
--- a/src/abstract/CSBondCurve.sol
+++ b/src/abstract/CSBondCurve.sol
@@ -116,7 +116,7 @@ abstract contract CSBondCurve is ICSBondCurve, Initializable {
         BondCurveIntervalInput[] calldata intervals
     ) internal {
         CSBondCurveStorage storage $ = _getCSBondCurveStorage();
-        if (curveId > $.bondCurves.length - 1) {
+        if (curveId >= $.bondCurves.length) {
             revert InvalidBondCurveId();
         }
 
@@ -134,7 +134,7 @@ abstract contract CSBondCurve is ICSBondCurve, Initializable {
     function _setBondCurve(uint256 nodeOperatorId, uint256 curveId) internal {
         CSBondCurveStorage storage $ = _getCSBondCurveStorage();
         unchecked {
-            if (curveId > $.bondCurves.length - 1) {
+            if (curveId >= $.bondCurves.length) {
                 revert InvalidBondCurveId();
             }
         }
@@ -249,7 +249,7 @@ abstract contract CSBondCurve is ICSBondCurve, Initializable {
         uint256 curveId
     ) private view returns (BondCurve storage) {
         CSBondCurveStorage storage $ = _getCSBondCurveStorage();
-        if (curveId > $.bondCurves.length - 1) {
+        if (curveId >= $.bondCurves.length) {
             revert InvalidBondCurveId();
         }
 


### PR DESCRIPTION
## Summary
- use `curveId >= $.bondCurves.length` for bounds checks in `_updateBondCurve`, `_setBondCurve`, and `_getCurveInfo`

## Testing
- `forge test`

------
https://chatgpt.com/codex/tasks/task_b_684acde6a7e483219164de49cf893529