### PR TITLE
Fix bond curve length error handling

### DIFF
--- a/docs/src/src/interfaces/ICSBondCurve.sol/interface.ICSBondCurve.md
+++ b/docs/src/src/interfaces/ICSBondCurve.sol/interface.ICSBondCurve.md
@@ -176,12 +176,14 @@ event BondCurveSet(uint256 indexed nodeOperatorId, uint256 curveId);
 ```solidity
 error InvalidBondCurveLength();
 ```
+Occurs when the provided curve contains fewer intervals than `MIN_CURVE_LENGTH`.
 
 ### InvalidBondCurveMaxLength
 
 ```solidity
 error InvalidBondCurveMaxLength();
 ```
+Occurs when the provided curve contains more intervals than `MAX_CURVE_LENGTH`.
 
 ### InvalidBondCurveValues
 

--- a/src/abstract/CSBondCurve.sol
+++ b/src/abstract/CSBondCurve.sol
@@ -259,11 +259,11 @@ abstract contract CSBondCurve is ICSBondCurve, Initializable {
     function _checkBondCurve(
         BondCurveIntervalInput[] calldata intervals
     ) private pure {
-        if (
-            intervals.length < MIN_CURVE_LENGTH ||
-            intervals.length > MAX_CURVE_LENGTH
-        ) {
+        if (intervals.length < MIN_CURVE_LENGTH) {
             revert InvalidBondCurveLength();
+        }
+        if (intervals.length > MAX_CURVE_LENGTH) {
+            revert InvalidBondCurveMaxLength();
         }
 
         if (intervals[0].minKeysCount != 1) {


### PR DESCRIPTION
## Summary
- throw `InvalidBondCurveMaxLength` when a curve has too many intervals
- document conditions for `InvalidBondCurveLength` and `InvalidBondCurveMaxLength`

## Testing
- `forge test --no-match-path 'test/fork/*' -vvv` *(fails: could not run tests in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_684acbecd06483219e721c8e635f0f12