### PR TITLE
Add CSBondCurve uninitialized tests

### DIFF
--- a/test/CSBondCurve.t.sol
+++ b/test/CSBondCurve.t.sol
@@ -54,6 +54,16 @@ contract CSBondCurveInitTest is Test {
         vm.expectRevert(ICSBondCurve.InvalidInitializationCurveId.selector);
         bondCurve.initialize(_bondCurve);
     }
+
+    function test_setBondCurve_RevertWhen_NotInitialized() public {
+        vm.expectRevert(ICSBondCurve.InvalidBondCurveId.selector);
+        bondCurve.setBondCurve(0, 0);
+    }
+
+    function test_updateBondCurve_RevertWhen_NotInitialized() public {
+        vm.expectRevert(ICSBondCurve.InvalidBondCurveId.selector);
+        bondCurve.updateBondCurve(0, new ICSBondCurve.BondCurveIntervalInput[](0));
+    }
 }
 
 contract CSBondCurveTest is Test {


### PR DESCRIPTION
## Summary
- add tests to check `setBondCurve` and `updateBondCurve` revert when called before initialization

## Testing
- `forge test --match-path test/CSBondCurve.t.sol --match-test test_setBondCurve_RevertWhen_NotInitialized -vvv`
- `forge test --match-path test/CSBondCurve.t.sol --match-test test_updateBondCurve_RevertWhen_NotInitialized -vvv`


------
https://chatgpt.com/codex/tasks/task_b_684acdedfd9c83219997c733a8d6833b