### PR TITLE
Fix comment grammar in CSModule

### DIFF
--- a/docs/src/src/CSModule.sol/contract.CSModule.md
+++ b/docs/src/src/CSModule.sol/contract.CSModule.md
@@ -589,7 +589,7 @@ operator in this module has actually received any updated counts as a result of 
 but given that the total number of exited validators returned from getStakingModuleSummary
 is the same as StakingRouter expects based on the total count received from the oracle.
 
-*This method is not used in CSM, hence it is do nothing*
+*This method is not used in CSM, hence it does nothing*
 
 *NOTE: No role checks because of empty body to save bytecode.*
 

--- a/src/CSModule.sol
+++ b/src/CSModule.sol
@@ -454,7 +454,7 @@ contract CSModule is
     }
 
     /// @inheritdoc IStakingModule
-    /// @dev This method is not used in CSM, hence it is do nothing
+    /// @dev This method is not used in CSM, hence it does nothing
     /// @dev NOTE: No role checks because of empty body to save bytecode.
     function onExitedAndStuckValidatorsCountsUpdated() external {
         // solhint-disable-previous-line no-empty-blocks


### PR DESCRIPTION
## Summary
- fix grammar in `onExitedAndStuckValidatorsCountsUpdated` comment
- sync generated docs

## Testing
- `just test-unit` *(fails: Compiling only)*

------
https://chatgpt.com/codex/tasks/task_b_684adc491b88832187258b160c5fba30